### PR TITLE
Restructure folders

### DIFF
--- a/nems-platform.make
+++ b/nems-platform.make
@@ -2,80 +2,80 @@
 ; Contributed modules
 ; ===================
 
-projects[admin_language][subdir] = "contrib"
+projects[admin_language][subdir] = "contrib/nems_platform"
 projects[admin_language][version] = "1.0-beta1"
 
-projects[block_access][subdir] = "contrib"
+projects[block_access][subdir] = "contrib/nems_platform"
 projects[block_access][version] = "1.6"
 
-projects[blockreference][subdir] = "contrib"
+projects[blockreference][subdir] = "contrib/nems_platform"
 projects[blockreference][version] = "2.3"
 
-projects[ckeditor_tabber][subdir] = "contrib"
+projects[ckeditor_tabber][subdir] = "contrib/nems_platform"
 projects[ckeditor_tabber][version] = "1.3"
 
-projects[collapsiblock][subdir] = "contrib"
+projects[collapsiblock][subdir] = "contrib/nems_platform"
 projects[collapsiblock][version] = "1.1"
 
-projects[entityconnect][subdir] = "contrib"
+projects[entityconnect][subdir] = "contrib/nems_platform"
 projects[entityconnect][version] = "1.0-rc5"
 
-projects[eva][subdir] = "contrib"
+projects[eva][subdir] = "contrib/nems_platform"
 projects[eva][version] = "1.2"
 
-projects[features_extra][subdir] = "contrib"
+projects[features_extra][subdir] = "contrib/nems_platform"
 projects[features_extra][version] = "1.0"
 
-projects[features_roles_permissions][subdir] = "contrib"
+projects[features_roles_permissions][subdir] = "contrib/nems_platform"
 projects[features_roles_permissions][version] = "1.2"
 
-projects[feeds_et][subdir] = "contrib"
+projects[feeds_et][subdir] = "contrib/nems_platform"
 projects[feeds_et][version] = "1.x-dev"
 
-projects[feeds_xpathparser][subdir] = "contrib"
+projects[feeds_xpathparser][subdir] = "contrib/nems_platform"
 projects[feeds_xpathparser][version] = "1.1"
 
-projects[insert_block][subdir] = "contrib"
+projects[insert_block][subdir] = "contrib/nems_platform"
 projects[insert_block][version] = "1.x-dev"
 
-projects[integration][subdir] = "contrib"
+projects[integration][subdir] = "contrib/nems_platform"
 projects[integration][version] = "1.x-dev"
 
-projects[media_feeds][subdir] = "contrib"
+projects[media_feeds][subdir] = "contrib/nems_platform"
 projects[media_feeds][version] = "2.x-dev"
 
-projects[menu_admin_per_menu][subdir] = "contrib"
+projects[menu_admin_per_menu][subdir] = "contrib/nems_platform"
 projects[menu_admin_per_menu][version] = "1.1"
 
-projects[nodeblock][subdir] = "contrib"
+projects[nodeblock][subdir] = "contrib/nems_platform"
 projects[nodeblock][version] = "1.7"
 
-projects[owlcarousel][subdir] = "contrib"
+projects[owlcarousel][subdir] = "contrib/nems_platform"
 projects[owlcarousel][version] = "1.5"
 
-projects[pathologic][subdir] = "contrib"
+projects[pathologic][subdir] = "contrib/nems_platform"
 projects[pathologic][version] = "3.1"
 
-projects[rabbit_hole][subdir] = "contrib"
+projects[rabbit_hole][subdir] = "contrib/nems_platform"
 projects[rabbit_hole][version] = "2.23"
 
-projects[remote_stream_wrapper][subdir] = "contrib"
+projects[remote_stream_wrapper][subdir] = "contrib/nems_platform"
 projects[remote_stream_wrapper][version] = "1.0-rc1"
 
-projects[role_delegation][subdir] = "contrib"
+projects[role_delegation][subdir] = "contrib/nems_platform"
 projects[role_delegation][version] = "1.1"
 
-projects[taxonomy_access_fix][subdir] = "contrib"
+projects[taxonomy_access_fix][subdir] = "contrib/nems_platform"
 projects[taxonomy_access_fix][version] = "2.3"
 
-projects[tb_megamenu][subdir] = "contrib"
+projects[tb_megamenu][subdir] = "contrib/nems_platform"
 projects[tb_megamenu][version] = "1.0-rc2"
 
-projects[tocify][subdir] = "contrib"
+projects[tocify][subdir] = "contrib/nems_platform"
 projects[tocify][version] = "1.0"
 
-projects[views_block_filter_block][subdir] = "contrib"
+projects[views_block_filter_block][subdir] = "contrib/nems_platform"
 projects[views_block_filter_block][version] = "1.0-beta2"
 
-projects[weight][subdir] = "contrib"
+projects[weight][subdir] = "contrib/nems_platform"
 projects[weight][version] = "3.1"

--- a/post-install.sh
+++ b/post-install.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 
 # Remove nems related sources if any.
-rm -rf lib/features/nems
-rm -rf lib/themes/nems
+rm -rf lib/features/nems_platform
+rm -rf lib/themes/nems_platform
 rm -f resources/nems-platform.make
 
 # Create clean folders
-mkdir lib/features/nems
-mkdir lib/themes/nems
+mkdir lib/features/nems_platform
+mkdir lib/themes/nems_platform
 
 # Copy the sources in place.
-cp -r vendor/ec-europa/nems-platform/modules/features/* lib/features/nems
-cp -r vendor/ec-europa/nems-platform/themes/* lib/themes/nems
+cp -r vendor/ec-europa/nems-platform/modules/features/* lib/features/nems_platform
+cp -r vendor/ec-europa/nems-platform/themes/* lib/themes/nems_platform
 cp vendor/ec-europa/nems-platform/nems-platform.make resources/nems-platform.make
 
 echo NEMS Sources copied...


### PR DESCRIPTION
This change is necessary for reps platform because they use custom modules. With the post install it was possible for deployers to lose custom modules that were provided by the subsite. To keep in line with that new standard for sub-platforms we need to change the folderstructure.

This change requires all subsites to undergo a "drush rr" to point to the correct system path.
https://webgate.ec.europa.eu/CITnet/jira/browse/MULTISITE-12252

Please test this before merging. You can test it by changing the repo in the composer.json of the subsite project from ec-europa to verbruggenalex.
